### PR TITLE
added evalues to structure of tfb_fpc object

### DIFF
--- a/R/tfb-fpc-utils.R
+++ b/R/tfb-fpc-utils.R
@@ -32,10 +32,11 @@ fpc_wsvd.matrix <- function(data, arg, pve = .995) {
   pve_observed <- cumsum(pc$d^2) / sum(pc$d^2)
   use <- min(which(pve_observed >= pve))
   efunctions <- pc$v[, 1:use] / sqrt(w)
+  evalues <- pc$d[1:use]
   scores <- t(qr.coef(qr(efunctions), t(data_wc) / sqrt(w))) #!!
   list(
     mu = mean, efunctions = efunctions,
-    scores = scores, npc = use
+    scores = scores, npc = use, evalues = evalues
   )
 }
 fpc_wsvd.data.frame <- function(data, arg, pve = .995) { 

--- a/R/tfb-fpc.R
+++ b/R/tfb-fpc.R
@@ -34,6 +34,7 @@ new_tfb_fpc <- function(data, domain = NULL, resolution = NULL,
     basis_matrix = t(fpc),
     arg = arg,
     resolution = resolution,
+    score_variance = fpc_spec$evalues,
     class = c("tfb_fpc", "tfb", "tf")
   )
 }


### PR DESCRIPTION
Hey Fabian, 

I added a structure element to class tfb_fpc called ‘score_variance’ that contains the eigenvalues of the fpc decomposition. My understanding is that from fpc_wsvd the evalues are ‘d’ so I return these when fpc_wsvd is the chosen fpca method, let me know if I am mistaken.

Having the eigenvalues accessible as part of the attributes for a tfb_fpc object will be nice for the refunder fpca function.