### PR TITLE
refactor: use all_of for latest tidyselect and use expect_identical

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
     person("Julia", "Wrobel", role = "aut",
            comment = c(ORCID = "0000-0001-6783-1421")),
     person("Maximilian", "Muecke", role = "ctb",
-           comment = c(ORCID = "0000-0002-9609-3197"))
+           comment = c(ORCID = "0009-0000-9432-9795"))
   )
 Description: Representing, visualizing, describing and wrangling tidy
     functional data, based on {tf}.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R: c(
     person("Fabian", "Scheipl", , "fabian.scheipl@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8172-3603")),
     person("Jeff", "Goldsmith", role = "aut"),
-    person("Julia", "Wrobel", role = "aut", 
+    person("Julia", "Wrobel", role = "aut",
            comment = c(ORCID = "0000-0001-6783-1421")),
     person("Maximilian", "Muecke", role = "ctb",
            comment = c(ORCID = "0000-0002-9609-3197"))
@@ -49,8 +49,8 @@ VignetteBuilder:
     knitr
 Remotes: 
     tidyfun/tf
+Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
-Config/testthat/edition: 3

--- a/R/tidyr.R
+++ b/R/tidyr.R
@@ -253,7 +253,7 @@ tf_nest <- function(data, ..., .id = "id", .arg = "arg", domain = NULL,
     list(value_vars, evaluator, domain, resolution),
     \(x, y, z, w) {
       data |>
-        select(id_var, arg_var, !!x) |>
+        select(!!id_var, !!arg_var, all_of(x)) |>
         tfd(evaluator = !!y, domain = z, resolution = w)
     }
   )

--- a/man/tidyfun-package.Rd
+++ b/man/tidyfun-package.Rd
@@ -41,7 +41,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Maximilian Muecke (\href{https://orcid.org/0000-0002-9609-3197}{ORCID}) [contributor]
+  \item Maximilian Muecke (\href{https://orcid.org/0009-0000-9432-9795}{ORCID}) [contributor]
 }
 
 }

--- a/tests/testthat/test-tidyr.R
+++ b/tests/testthat/test-tidyr.R
@@ -6,20 +6,20 @@ cca <- tfd(data$cca)
 test_that("tf_gather works", {
   expect_s3_class(tf_gather(d1)$cca, "tfd")
   expect_message(tf_gather(d1)$cca, "cca")
-  expect_equal(tf_gather(d1)$cca, cca)
+  expect_identical(tf_gather(d1)$cca, cca)
   expect_equal(
     tf_gather(d1)$cca, tf_gather(data[, 1:8], cca)$cca,
     ignore_attr = TRUE
   )
 
-  expect_equal(tf_gather(d2, -1)$cca, cca)
-  expect_equal(tf_gather(d2, -1)$id, d2$id)
-  expect_equal(tf_gather(d2, -1, key = "nuhnuh")$nuhnuh, tf_gather(d2, -1)$cca)
+  expect_identical(tf_gather(d2, -1)$cca, cca)
+  expect_identical(tf_gather(d2, -1)$id, d2$id)
+  expect_identical(tf_gather(d2, -1, key = "nuhnuh")$nuhnuh, tf_gather(d2, -1)$cca)
 
-  expect_equal(tf_gather(d2, -id)$cca, tf_gather(d2, -1)$cca)
-  expect_equal(tf_gather(d2, starts_with("cca"))$cca, tf_gather(d2, -1)$cca)
+  expect_identical(tf_gather(d2, -id)$cca, tf_gather(d2, -1)$cca)
+  expect_identical(tf_gather(d2, starts_with("cca"))$cca, tf_gather(d2, -1)$cca)
 
-  expect_equal(
+  expect_identical(
     attr(tf_gather(d1, evaluator = tf_approx_spline)$cca, "evaluator_name"),
     "tf_approx_spline"
   )
@@ -33,8 +33,8 @@ test_that("tf_spread works", {
     tf_spread(d, f, sep = NULL)[, -1], as.data.frame(as.matrix(d$f)),
     ignore_attr = TRUE
   )
-  expect_equal(tf_spread(d, f), tf_spread(d, -g))
-  expect_equal(tf_spread(d, f), tf_spread(d))
+  expect_identical(tf_spread(d, f), tf_spread(d, -g))
+  expect_identical(tf_spread(d, f), tf_spread(d))
   expect_warning(
     tf_spread(d, f, arg = seq(0, 1, length.out = 20), sep = NULL), "interpolate = FALSE"
   )
@@ -82,7 +82,7 @@ test_that("tf_nest works", {
 
   g <- rnorm(3)
   data <- bind_cols(data, g = rep(g, e = tf_count(f1)))
-  expect_equal(tf_nest(data, value.x:value.y)$g, g)
+  expect_identical(tf_nest(data, value.x:value.y)$g, g)
   data <- bind_cols(data, f = rep(rnorm(nrow(data))))
   expect_error(tf_nest(data, value.x:value.y), "Can't nest")
 })
@@ -96,7 +96,7 @@ test_that("tf_unnest works", {
   f2 <- tf_rgp(3, 11L)
   data <- dplyr::inner_join(tf_unnest(f1), tf_unnest(f2), by = c("id", "arg"))
   tfdata <- tf_nest(data)
-  expect_equal(NCOL(tf_unnest(tfdata, cols = c(value.x, value.y))), 5)
+  expect_identical(NCOL(tf_unnest(tfdata, cols = c(value.x, value.y))), 5)
   expect_equal(
     as.matrix(tf_unnest(tfdata, cols = c(value.x, value.y))[-c(1, 4)]),
     as.matrix(data[, 2:4]),

--- a/tests/testthat/test-tidyr.R
+++ b/tests/testthat/test-tidyr.R
@@ -96,7 +96,7 @@ test_that("tf_unnest works", {
   f2 <- tf_rgp(3, 11L)
   data <- dplyr::inner_join(tf_unnest(f1), tf_unnest(f2), by = c("id", "arg"))
   tfdata <- tf_nest(data)
-  expect_identical(NCOL(tf_unnest(tfdata, cols = c(value.x, value.y))), 5)
+  expect_identical(NCOL(tf_unnest(tfdata, cols = c(value.x, value.y))), 5L)
   expect_equal(
     as.matrix(tf_unnest(tfdata, cols = c(value.x, value.y))[-c(1, 4)]),
     as.matrix(data[, 2:4]),


### PR DESCRIPTION
Closes: https://github.com/tidyfun/tidyfun/issues/158

- Replace `expect_equal` for stricter `expect_identical` where possible
- Use `all_of` where relevant for new tidyselect for deprecation warnings
- Apply `usethis::use_tidy_description()`