### PR TITLE
feat: correct key glyphs for GeomMeatballs

### DIFF
--- a/R/geom-spaghetti.R
+++ b/R/geom-spaghetti.R
@@ -43,7 +43,9 @@ scale_type.tf <- function(x) "identity"
 #' @family tidyfun visualization
 #' @usage NULL
 #' @format NULL
-StatTf <- ggproto("StatTf", Stat,
+StatTf <- ggproto(
+  "StatTf",
+  Stat,
   required_aes = "y",
   setup_params = function(data, params) {
     if (is.null(params$arg)) {
@@ -78,12 +80,25 @@ StatTf <- ggproto("StatTf", Stat,
 #' @family tidyfun visualization
 #' @inheritParams ggplot2::stat_identity
 #' @param na.rm remove NAs? defaults to `TRUE`
-stat_tf <- function(mapping = NULL, data = NULL, geom = "spaghetti",
-                    position = "identity", na.rm = TRUE, show.legend = NA,
-                    inherit.aes = TRUE, arg = NULL, ...) {
+stat_tf <- function(
+  mapping = NULL,
+  data = NULL,
+  geom = "spaghetti",
+  position = "identity",
+  na.rm = TRUE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  arg = NULL,
+  ...
+) {
   ggplot2::layer(
-    stat = StatTf, data = data, mapping = mapping, geom = geom,
-    position = position, show.legend = show.legend, inherit.aes = inherit.aes,
+    stat = StatTf,
+    data = data,
+    mapping = mapping,
+    geom = geom,
+    position = position,
+    show.legend = show.legend,
+    inherit.aes = inherit.aes,
     params = list(na.rm = na.rm, arg = arg, ...)
   )
 }
@@ -95,12 +110,24 @@ stat_tf <- function(mapping = NULL, data = NULL, geom = "spaghetti",
 #' @family tidyfun visualization
 #' @format NULL
 #' @param arg where to evaluate the functions in `y` -- defaults to the default ;)
-geom_spaghetti <- function(mapping = NULL, data = NULL,
-                           position = "identity", na.rm = TRUE, show.legend = NA,
-                           inherit.aes = TRUE, arg = NULL, ...) {
+geom_spaghetti <- function(
+  mapping = NULL,
+  data = NULL,
+  position = "identity",
+  na.rm = TRUE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  arg = NULL,
+  ...
+) {
   ggplot2::layer(
-    stat = StatTf, data = data, mapping = mapping, geom = "spaghetti",
-    position = position, show.legend = show.legend, inherit.aes = inherit.aes,
+    stat = StatTf,
+    data = data,
+    mapping = mapping,
+    geom = "spaghetti",
+    position = position,
+    show.legend = show.legend,
+    inherit.aes = inherit.aes,
     params = list(na.rm = na.rm, arg = arg, ...)
   )
 }
@@ -109,24 +136,28 @@ geom_spaghetti <- function(mapping = NULL, data = NULL,
 #' @family tidyfun visualization
 #' @usage NULL
 #' @format NULL
-GeomSpaghetti <- ggplot2::ggproto("GeomSpaghetti", ggplot2::Geom,
+GeomSpaghetti <- ggplot2::ggproto(
+  "GeomSpaghetti",
+  ggplot2::Geom,
+  default_aes = ggplot2::aes(
+    colour = "black",
+    linewidth = 0.5,
+    linetype = 1,
+    alpha = 0.5
+  ),
+  draw_group = function(data, panel_params, coord) {
+    GeomLine$draw_panel(data, panel_params, coord)
+  },
+  draw_key = GeomLine$draw_key,
+  required_aes = c("x", "y", "group"),
+  setup_data = function(data, params) {
+    GeomLine$setup_data(data, params)
+  },
   setup_params = function(data, params) {
     # TODO: implement proper "orientation" - see extending ggplot vignette
     params$flipped_aes <- FALSE
     params
-  },
-  setup_data = function(data, params) {
-    GeomLine$setup_data(data, params)
-  },
-  draw_group = function(data, panel_params, coord) {
-    GeomLine$draw_panel(data, panel_params, coord)
-  },
-  default_aes = ggplot2::aes(
-    colour = "black", linewidth = 0.5,
-    linetype = 1, alpha = 0.5
-  ),
-  draw_key = GeomLine$draw_key,
-  required_aes = c("x", "y", "group")
+  }
 )
 
 #-------------------------------------------------------------------------------
@@ -137,13 +168,25 @@ GeomSpaghetti <- ggplot2::ggproto("GeomSpaghetti", ggplot2::Geom,
 #' @format NULL
 #' @importFrom grid gList
 #' @param spaghetti plot noodles along with meatballs? defaults to TRUE.
-geom_meatballs <- function(mapping = NULL, data = NULL,
-                           position = "identity", na.rm = TRUE, show.legend = NA,
-                           inherit.aes = TRUE, arg = NULL, spaghetti = TRUE,
-                           ...) {
+geom_meatballs <- function(
+  mapping = NULL,
+  data = NULL,
+  position = "identity",
+  na.rm = TRUE,
+  show.legend = NA,
+  inherit.aes = TRUE,
+  arg = NULL,
+  spaghetti = TRUE,
+  ...
+) {
   ggplot2::layer(
-    stat = StatTf, data = data, mapping = mapping, geom = "meatballs",
-    position = position, show.legend = show.legend, inherit.aes = inherit.aes,
+    stat = StatTf,
+    data = data,
+    mapping = mapping,
+    geom = "meatballs",
+    position = position,
+    show.legend = show.legend,
+    inherit.aes = inherit.aes,
     params = list(na.rm = na.rm, arg = arg, spaghetti = spaghetti, ...)
   )
 }
@@ -152,7 +195,32 @@ geom_meatballs <- function(mapping = NULL, data = NULL,
 #' @family tidyfun visualization
 #' @usage NULL
 #' @format NULL
-GeomMeatballs <- ggplot2::ggproto("GeomMeatball", ggplot2::Geom,
+GeomMeatballs <- ggplot2::ggproto(
+  "GeomMeatball",
+  ggplot2::Geom,
+  default_aes = ggplot2::aes(
+    colour = "black",
+    linewidth = 0.5,
+    size = 0.5,
+    linetype = 1,
+    alpha = 0.5,
+    shape = 19,
+    fill = NA,
+    stroke = 0.5
+  ),
+  draw_group = function(data, panel_params, coord, spaghetti = TRUE) {
+    grid::gList(
+      if (spaghetti) GeomLine$draw_panel(data, panel_params, coord),
+      GeomPoint$draw_panel(data, panel_params, coord)
+    )
+  },
+  draw_key = function(data, params, size) {
+    grid::grobTree(
+      if (params$spaghetti) draw_key_path(data, params, size),
+      draw_key_point(data, params, size)
+    )
+  },
+  required_aes = c("x", "y", "group"),
   setup_params = function(data, params) {
     # TODO: implement proper "orientation" - see extending ggplot vignette
     params$flipped_aes <- FALSE
@@ -160,17 +228,5 @@ GeomMeatballs <- ggplot2::ggproto("GeomMeatball", ggplot2::Geom,
   },
   setup_data = function(data, params) {
     GeomLine$setup_data(data, params)
-  },
-  draw_group = function(data, panel_params, coord, spaghetti = TRUE) {
-    grid::gList(
-      if (spaghetti) GeomLine$draw_panel(data, panel_params, coord),
-      GeomPoint$draw_panel(data, panel_params, coord)
-    )
-  },
-  default_aes = ggplot2::aes(
-    colour = "black", linewidth = 0.5, size = 0.5,
-    linetype = 1, alpha = 0.5, shape = 19, fill = NA, stroke = 0.5
-  ),
-  draw_key = GeomLine$draw_key,
-  required_aes = c("x", "y", "group")
+  }
 )


### PR DESCRIPTION
- use corret key glyphs in `geom_meatballs()`, in summary just add point glyphs when `spaghetti = TRUE`
- add air.toml for air format